### PR TITLE
Disable RSpec/MultipleMemoizedHelpers

### DIFF
--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -14,3 +14,6 @@ RSpec/NestedGroups:
 
 RSpec/MultipleExpectations:
   Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false


### PR DESCRIPTION
The description of the cop is:

> Checks if example groups contain too many `let` and `subject` calls.

I don't understand why that would be prohibited by default since it seems to me to be a good thing to have let blocks that can be extended in contexts.