### PR TITLE
Better multiline line breaks

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -64,6 +64,18 @@ Layout/AccessModifierIndentation:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
+Layout/MultilineArrayLineBreaks:
+  Enabled: true
+
+Layout/MultilineHashKeyLineBreaks:
+  Enabled: true
+
+Layout/MultilineMethodArgumentLineBreaks:
+  Enabled: true
+
+Layout/MultilineMethodParameterLineBreaks:
+  Enabled: true
+
 Metrics/ParameterLists:
   Enabled: false
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -76,6 +76,9 @@ Layout/MultilineMethodArgumentLineBreaks:
 Layout/MultilineMethodParameterLineBreaks:
   Enabled: true
 
+Layout/LineLength:
+  IgnoredPatterns: ['^ *def']
+
 Metrics/ParameterLists:
   Enabled: false
 


### PR DESCRIPTION
The multiline line breaks looks better if each item is on its own line.
Method definitions does not look better when each arguments are on separate lines.

The intended policing is this:
# bad
foo = [a, b,
  c
]
end

# good
foo = [
  a,
  b,
  c
]
end

# good
foo = [a, b, c]


And to ignore line length limit for lines begins with 'def'.