### PR TITLE
First element new line

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -79,6 +79,18 @@ Layout/MultilineMethodParameterLineBreaks:
 Layout/LineLength:
   IgnoredPatterns: ['^ *def']
 
+Layout/FirstArrayElementLineBreak:
+  Enabled: true
+
+Layout/FirstHashElementLineBreak:
+  Enabled: true
+
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: true
+
+Layout/FirstMethodParameterLineBreak:
+  Enabled: true
+
 Metrics/ParameterLists:
   Enabled: false
 


### PR DESCRIPTION
In general I think it looks neater if the first element in a multiline array/hash/method-parameter/arguments is on a new line.
This rule does this:
# bad
{ a: 1,
  b: 2}

# good
{
  a: 1,
  b: 2 }

But in conjunction with the default MultilineXBraceLayout using symetrical enforcment and TrailingCommaInXLiteral the result will be:
# bad
{ a: 1,
  b: 2}

# good
{
  a: 1,
  b: 2,
}