### PR TITLE
Use snake_case for numbering variables

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -108,3 +108,6 @@ Naming/MethodParameterName:
 
 Metrics/MethodLength:
   Enabled: false
+
+Naming/VariableNumber:
+  EnforcedStyle: snake_case


### PR DESCRIPTION
When numbering variables we usually use snake_case like 'ad_unit_1'.
This is because we use snake case for variable names.

Instead of using the default which would be 'ad_unit1', we should keep using snake case for the numbering.