### PR TITLE
Disable Naming/VariableNumber

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -110,4 +110,4 @@ Metrics/MethodLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: snake_case
+  Enabled: false


### PR DESCRIPTION
In https://github.com/burtcorp/rubocop-config/pull/6 we changed Naming/VariableNumber to snake_case since we usually name variables like `ad_unit_1`. This unfortunately causes other offences since you might have a symbol `impressions_q1` because that is what it is called in the API.

In my opinion we should just disable this cop.