### PR TITLE
Remove enforcement of shorthand syntax

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -34,6 +34,9 @@ Style/TrailingCommaInArguments:
 Style/Lambda:
   Enabled: false
 
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never
+
 Layout/IndentationWidth:
   Enabled: false
 


### PR DESCRIPTION
Sometime the key and a values variable name has the same name, which results in after ruby 3.1 to be enforced to remove the value. This looks weird in my oppinion, this removes the enforcement of that.

With `EnforcedShorthandSyntax: always` (default)

```ruby
company = "Company name"

#bad
{
  company: company
}

#good
{
  company:
}
``` 

With `EnforcedShorthandSyntax: never`

```ruby
company = "Company name"

#bad
{
  company:
}

#good
{
  company: company
}
``` 