### PR TITLE
Fix deprecation warning

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -80,7 +80,7 @@ Layout/MultilineMethodParameterLineBreaks:
   Enabled: true
 
 Layout/LineLength:
-  IgnoredPatterns: ['^ *def']
+  AllowedPatterns: ['^ *def']
 
 Layout/FirstArrayElementLineBreak:
   Enabled: true


### PR DESCRIPTION
Rubocop is showing a warning because we use an obsolete parameter:

```
Warning: obsolete parameter `IgnoredPatterns` (for `Layout/LineLength`) found in .rubocop-https---raw-githubusercontent-com-burtcorp-rubocop-config-master-rubocop-yml `IgnoredPatterns` has been renamed to `AllowedPatterns`.
```