### PR TITLE
Use "end" case indentation style

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -120,3 +120,6 @@ Metrics/MethodLength:
 
 Naming/VariableNumber:
   Enabled: false
+
+Layout/CaseIndentation:
+  EnforcedStyle: end


### PR DESCRIPTION
We prefer this style:
```ruby
memo[key] = case key
when :foo
  'FOO'
when :bar
  'BAR'
else
  'BAZ'
end
```

The default style is this:
```ruby
memo[key] = case key
            when :foo
              'FOO'
            when :bar
              'BAR'
            else
              'BAZ'
            end
```