### PR TITLE
Migrate to plugins

### DIFF
--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -1,4 +1,4 @@
-require: rubocop-rspec
+plugins: rubocop-rspec
 
 RSpec/LeadingSubject:
   Enabled: false


### PR DESCRIPTION
When running the ruby-rubocop extension in Cursor, I get the following warning over and over again:

> rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec` in /Users/stenlarsson/Documents/src/api-analytics/.rubocop-https---raw-githubusercontent-com-burtcorp-rubocop-config-master-rubocop-rspec-yml. For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.