### PR TITLE
Change case indentation style to end

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -37,6 +37,9 @@ Style/Lambda:
 Style/HashSyntax:
   EnforcedShorthandSyntax: never
 
+Layout/CaseIndentation:
+  EnforcedStyle: end
+
 Layout/IndentationWidth:
   Enabled: false
 


### PR DESCRIPTION
Since `end` aligns with the variable, I think also `when` should align with `end` instead of `case`.

Before:

```ruby
a = case n
    when 0
      x * 2
    else
      y / 3
end
```

After:

```ruby
a = case n
when 0
  x * 2
else
  y / 3
end
```